### PR TITLE
Change the conditions under which a comment color is set

### DIFF
--- a/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
@@ -42,7 +42,8 @@ void SAutoSizeCommentNode::Construct(const FArguments& InArgs, class UEdGraphNod
 
 	// Set comment color
 	FLinearColor DefaultColor = GetMutableDefault<UAutoSizeSettings>()->DefaultCommentColor;
-	if (CommentNode && CommentNode->CommentColor == DefaultColor)
+	// If the comment color is white, then the color may be changed
+	if (CommentNode && CommentNode->CommentColor == FLinearColor::White)
 	{
 		if (GetMutableDefault<UAutoSizeSettings>()->bUseRandomColor)
 			CommentNode->CommentColor = FLinearColor::MakeRandomColor();


### PR DESCRIPTION
Now the plugin checks if the comment color is "White," and if so, it proceeds to set the comment color. Previously, there seemed to be a bug in which comments were never set to the user-selected "Default Comment Color" unless the "Default Comment Color" was already white.