### PR TITLE
Comment nodes no longer become 'dirty' when their position updates

### DIFF
--- a/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
@@ -711,7 +711,7 @@ void SAutoSizeCommentNode::ResizeToFit()
 		// move to desired pos
 		if (!GetPosition().Equals(DesiredPos, .1f))
 		{
-			GraphNode->Modify();
+			//GraphNode->Modify();
 			GraphNode->NodePosX = DesiredPos.X;
 			GraphNode->NodePosY = DesiredPos.Y;
 		}


### PR DESCRIPTION
Previously, the comment nodes were frequently becoming "dirty" (marking unsaved changes), so that even if you clicked "Save" on a blueprint actor, the asterisk by the blueprint name would often show up right away, as if the blueprint still needed to be saved. This appears to be because the position of the comment nodes is frequently being recalculated. Now the frequent positional change of the comment nodes doesn't 'dirty' the asset.

(I'm not sure if there's any unintended consequences of this)