### PR TITLE
Create a user setting to turn on "Color Bubbles" for comments

### DIFF
--- a/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp
@@ -58,6 +58,13 @@ void SAutoSizeCommentNode::Construct(const FArguments& InArgs, class UEdGraphNod
 			CommentNode->CommentColor = DefaultColor;
 		}
 	}
+
+	// If the "Force Color Comment Bubbles" user setting is checked
+	if (GetMutableDefault<UAutoSizeSettings>()->bForceColorCommentBubbles)
+	{
+		// Set this comment box to use a colored comment bubble
+		CommentNode->bColorCommentBubble = true;
+	}
 }
 
 void SAutoSizeCommentNode::MoveTo(const FVector2D& NewPosition, FNodeSet& NodeFilter)

--- a/Source/AutoSizeComments/Private/AutoSizeSettings.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeSettings.cpp
@@ -11,4 +11,5 @@ UAutoSizeSettings::UAutoSizeSettings(const FObjectInitializer& ObjectInitializer
 	bAggressivelyUseDefaultColor = false;
 	bMoveEmptyCommentBoxes = true;
 	EmptyCommentBoxSpeed = 10;
+	bForceColorCommentBubbles = false;
 }

--- a/Source/AutoSizeComments/Public/AutoSizeSettings.h
+++ b/Source/AutoSizeComments/Public/AutoSizeSettings.h
@@ -38,4 +38,8 @@ public:
 	/** The speed at which empty comment boxes move */
 	UPROPERTY(EditAnywhere, config, Category = Default)
 	float EmptyCommentBoxSpeed;
+
+	/** If enabled, this should set "Color Bubble" to true for every comment box that is created or loaded */
+	UPROPERTY(EditAnywhere, config, Category = Default)
+	bool bForceColorCommentBubbles;
 };


### PR DESCRIPTION
I added a setting to "Force Color Comment Bubbles." If enabled, it should set "Color Bubble" to true for comments when the "Construct" function executes on them. So if the user checks it, then every comment bubble should show up with the same background color as the comment.

(Personally, I think that colored comment bubbles seem nicer and less distracting as long as I use gray or somewhat desaturated tones for my comment colors)