### PR TITLE
Added Mac to whitelist

### DIFF
--- a/AutoSizeComments.uplugin
+++ b/AutoSizeComments.uplugin
@@ -20,7 +20,8 @@
 			"Type": "Editor",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win64"
+				"Win64",
+				"Mac"
 			]
 		}
 	]


### PR DESCRIPTION
Tested on macOS 10.14.2 (Mohave) with UE4.21.1

Works as expected, output:

`Performing 4 actions (8 in parallel)
[1/4] Compile SharedPCH.UnrealEd.h
[2/4] Compile Module.AutoSizeComments.cpp
[3/4] Compile Module.AutoSizeComments.gen.cpp
In file included from /Users/anadin/Projects/UE4Stuff/Empty/Plugins/AutoSizeComments/Intermediate/Build/Mac/UE4Editor/Development/AutoSizeComments/Module.AutoSizeComments.cpp:2:
/Users/anadin/Projects/UE4Stuff/Empty/Plugins/AutoSizeComments/Source/AutoSizeComments/Private/AutoSizeCommentNode.cpp:84:25: warning: declaration shadows a field of 'SAutoSizeCommentNode' [-Wshadow]
                UEdGraphNode_Comment* CommentNode = Cast<UEdGraphNode_Comment>(GraphNode);
                                      ^
/Users/anadin/Projects/UE4Stuff/Empty/Plugins/AutoSizeComments/Source/AutoSizeComments/Public/AutoSizeCommentNode.h:109:30: note: previous declaration is here
        class UEdGraphNode_Comment* CommentNode;
                                    ^
1 warning generated.
[4/4] Link UE4Editor-AutoSizeComments.dylib
`