### PR TITLE
Building on linux - cmake will fail unless strict casing is used in header files.

### DIFF
--- a/Source/AutoSizeComments/Private/AutoSizeCommentsCacheFile.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentsCacheFile.cpp
@@ -10,7 +10,7 @@
 #include "EdGraphNode_Comment.h"
 #include "AssetRegistry/Public/AssetRegistryModule.h"
 #include "AssetRegistry/Public/AssetRegistryState.h"
-#include "Core/Public/HAL/PlatformFilemanager.h"
+#include "Core/Public/HAL/PlatformFileManager.h"
 #include "Core/Public/Misc/CoreDelegates.h"
 #include "Core/Public/Misc/FileHelper.h"
 #include "EdGraph/EdGraph.h"

--- a/Source/AutoSizeComments/Private/AutoSizeCommentsNotifications.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentsNotifications.cpp
@@ -2,7 +2,7 @@
 
 #include "AutoSizeCommentsNotifications.h"
 
-#include "AutoSizeCommentsMacros.h"
+#include "AutoSIzeCommentsMacros.h"
 #include "AutoSizeCommentsModule.h"
 #include "AutoSizeCommentsSettings.h"
 #include "ISourceControlModule.h"

--- a/Source/AutoSizeComments/Public/AutoSizeCommentsGraphNode.h
+++ b/Source/AutoSizeComments/Public/AutoSizeCommentsGraphNode.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "AutoSizeCommentsMacros.h"
+#include "AutoSIzeCommentsMacros.h"
 #include "SGraphNode.h"
 
 enum class ECommentCollisionMethod : uint8;


### PR DESCRIPTION
Resolves #20 