### PR TITLE
Couple of QoL changes for use of this as a source plugin

### DIFF
--- a/AutoSizeComments.uplugin
+++ b/AutoSizeComments.uplugin
@@ -10,7 +10,6 @@
   "DocsURL": "",
   "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/ae89a2c4ab384de0a3f213b23de324f3",
   "SupportURL": "https://forums.unrealengine.com/community/released-projects/1540542",
-  "EngineVersion": "5.1.0",
   "CanContainContent": false,
   "IsBetaVersion": false,
   "Installed": true,

--- a/AutoSizeComments.uplugin
+++ b/AutoSizeComments.uplugin
@@ -12,7 +12,7 @@
   "SupportURL": "https://forums.unrealengine.com/community/released-projects/1540542",
   "CanContainContent": false,
   "IsBetaVersion": false,
-  "Installed": true,
+  "Installed": false,
   "Modules": [
     {
       "Name": "AutoSizeComments",


### PR DESCRIPTION
So because of https://github.com/fpwong/AutoSizeComments/issues/23 I changed to using this as a source plugin, and needed to change a couple of things in the .uplugin file to make it work nicely:

* Remove EngineVersion: makes it work in any version it'll build successfully in (I'm still using 5.0) without complaining at startup
* Change Installed to false: gets rid of the "You project file is out of date" prompts at startup. As a source plugin it shouldn't be in your .uproject with a Marketplace URL but if Installed=true the editor insists on adding it back all the time

This is how I have all my source plugins set up under my project. 

Obviously this means when you're building for the Marketplace you have to change these settings, but if you're doing a build for more than one UE version you have to do that anyway.